### PR TITLE
Fix where all

### DIFF
--- a/pyfireconsole/queries/where_clouse.py
+++ b/pyfireconsole/queries/where_clouse.py
@@ -1,0 +1,12 @@
+class WhereCondition:
+    def __init__(self, field, operator, value):
+        self.field = field
+        self.operator = operator
+        self.value = value
+
+    def to_dict(self):
+        return {
+            self.field: {
+                self.operator: self.value
+            }
+        }


### PR DESCRIPTION
WHY
The `PyfireModel#where` method was not functioning correctly, leading to get all documents of the collection.

WHAT
This pull request addresses the issue by implementing a fix that involves storing the where condition object.