### PR TITLE
as_json, delete

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,29 @@ user.my_books.first.user
 => User[users/XXXX](id='XXXX', name='John', email="john@example.com")
 ```
 
+### as_json
+You can convert PyfireDoc object to json serializable dict by using `as_json` method.
+```python
+# dump all admin users, not including sub collection
+User.all().as_json()
+
+# dump all admin users, not including sub collection
+User.where("role", "==", "admin").as_json()
+
+# dump all admin users, including sub collection
+User.where("role", "==", "admin").as_json(recursive=True)
+
+# you can also dump custom attributes
+class User(PyfireDoc):
+    name: str
+    email: str
+
+    def email_domain(self):
+        return self.email.split("@")[1]
+
+User.where("role", "==", "admin").as_json(recursive=True, include=["email_domain"])
+```
+
 ### Example
 We assume that you have a firestore database with the following structure:
 

--- a/pyfireconsole/queries/delete_query.py
+++ b/pyfireconsole/queries/delete_query.py
@@ -1,0 +1,14 @@
+from pyfireconsole.queries.abstract_query import AbstractQuery
+
+
+class DeleteQuery(AbstractQuery):
+    def __init__(self, collection_key: str, doc_id: str):
+        self.collection_key = collection_key
+        self.doc_id = doc_id
+
+    def exec(self) -> bool:
+        doc_ref = self.collection_ref(self.collection_key).document(self.doc_id)
+        if doc_ref.get().exists:
+            doc_ref.delete()
+            return not self.collection_ref(self.collection_key).document(self.doc_id).get().exists
+        return False

--- a/pyfireconsole/queries/query_runner.py
+++ b/pyfireconsole/queries/query_runner.py
@@ -2,6 +2,7 @@ from typing import Dict
 
 from pyfireconsole.db.connection import conn
 from pyfireconsole.queries.all_query import AllQuery
+from pyfireconsole.queries.delete_query import DeleteQuery
 from pyfireconsole.queries.get_query import GetQuery
 from pyfireconsole.queries.save_query import SaveQuery
 from pyfireconsole.queries.where_query import WhereQuery
@@ -28,4 +29,4 @@ class QueryRunner:
         return SaveQuery(self.collection_key, None, data).set_conn(self.conn).exec()
 
     def delete(self, id: str) -> None:
-        raise DeleteQuery(self.collection_key, id).set_conn(self.conn).exec()
+        return DeleteQuery(self.collection_key, id).set_conn(self.conn).exec()

--- a/samples/console_sample.py
+++ b/samples/console_sample.py
@@ -37,5 +37,5 @@ class Book(PyfireDoc):
 resolve_pyfire_model_names(globals())
 
 
-FirestoreConnection().initialize(project_id="YOUR_PROJECT_ID")
+FirestoreConnection().initialize(project_id="promptr-dev-prod")
 PyFireConsole().run()

--- a/tests/test_usecase.py
+++ b/tests/test_usecase.py
@@ -182,6 +182,16 @@ def test_as_json(mock_db):
         email="",
     ).save()
 
+    assert User.all().as_json() == [
+        {
+            "id": user.id,
+            "name": "John",
+            "email": "",
+        }
+    ]
+
+    assert User.where("name", "==", "Taro").as_json() == []
+
     assert user.as_json() == {
         "id": "12345",
         "name": "John",

--- a/tests/test_usecase.py
+++ b/tests/test_usecase.py
@@ -285,3 +285,34 @@ def test_has_many(mock_db):
 
     assert len([b for b in user.my_books]) == 2
     assert sorted([b.title for b in user.my_books]) == sorted(["Math", "History"])
+
+
+def test_delete(mock_db):
+    user = User.new(
+        name="John",
+        email="",
+    ).save()
+
+    book1 = Book.new(
+        title="Math",
+        user_id=user.id,
+        published_at=datetime.now(),
+        authors=["John", "Mary"],
+        publisher_ref="publisher/12345",
+    ).save()
+
+    _book2 = Book.new(
+        title="History",
+        user_id=user.id,
+        published_at=datetime.now(),
+        authors=["John", "Mary"],
+        publisher_ref="publisher/12345",
+    ).save()
+
+    assert len([b for b in user.my_books]) == 2
+    book1.delete()
+    assert len([b for b in user.my_books]) == 1
+    assert user.my_books.first().title == "History"
+
+    with pytest.raises(DocNotFoundException):
+        Book.find(book1.id)


### PR DESCRIPTION
## WHY
For convenience, we want to introduce an `as_json` method to convert PyFireModel instances into JSON-serializable dicts.

## WHAT
Implement the `as_json` method, drawing inspiration from Rails' ActiveRecord class.

Implement `delete` method.