### PR TITLE
Add order

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ print("==================== where ====================")
 print(Book.where("title", "==", "test"))  # => Book[] Make sure to create index in firestore for compound queries
 
 print("==================== where & order ====================")
-print(Book.where("title", "==", "test").order("name", "ASCENDING"))  # => Book[] Make sure to create index in firestore for compound queries
+print(Book.where("title", "==", "test").order("published_at", "ASCENDING"))  # => Book[] Make sure to create index in firestore for compound queries
 
 print("==================== has_many ====================")
 print(book.tags)  # => PyfireCollection[Tag]

--- a/README.md
+++ b/README.md
@@ -237,6 +237,9 @@ print(book.publisher_ref.path)  # => str (So far, we can't access publisher_ref.
 print("==================== where ====================")
 print(Book.where("title", "==", "test"))  # => Book[] Make sure to create index in firestore for compound queries
 
+print("==================== where & order ====================")
+print(Book.where("title", "==", "test").order("name", "ASCENDING"))  # => Book[] Make sure to create index in firestore for compound queries
+
 print("==================== has_many ====================")
 print(book.tags)  # => PyfireCollection[Tag]
 print(book.tags.first)  # => Tag

--- a/pyfireconsole/models/pyfire_model.py
+++ b/pyfireconsole/models/pyfire_model.py
@@ -4,7 +4,9 @@ import inflection
 from google.api_core.datetime_helpers import DatetimeWithNanoseconds
 from pydantic import BaseModel
 
+from pyfireconsole.models.order_condition import OrderCondition
 from pyfireconsole.queries.get_query import DocNotFoundException
+from pyfireconsole.queries.order_query import OrderDirection
 from pyfireconsole.queries.query_runner import QueryRunner
 from pyfireconsole.queries.where_clouse import WhereCondition
 
@@ -16,6 +18,7 @@ class PyfireCollection(Generic[ModelType]):
     _parent_model: Optional['PyfireDoc'] = None
     _collection: Optional[Iterable[dict]] = None
     _where_cond: Optional[WhereCondition] = None
+    _order_cond: Optional[OrderCondition] = None
 
     def __init__(self, model_class: Type[ModelType]):
         self.model_class = model_class
@@ -55,6 +58,9 @@ class PyfireCollection(Generic[ModelType]):
             self._collection = QueryRunner(self.obj_ref_key()).where(self._where_cond.field, self._where_cond.operator, self._where_cond.value)
         else:
             self._collection = QueryRunner(self.obj_ref_key()).all()
+
+        if self._order_cond is not None:
+            self._collection = QueryRunner(self.obj_ref_key()).order(self._order_cond.field, self._order_cond.direction)
 
         for doc in self._collection:
             doc = self.model_class._doc_field_load(doc)
@@ -101,6 +107,24 @@ class PyfireCollection(Generic[ModelType]):
         """
         coll = PyfireCollection(self.model_class)
         coll._where_cond = WhereCondition(field, operator, value)
+        if self._parent_model is not None:
+            coll.set_parent(self._parent_model)
+
+        return coll
+
+    def order(self, field: str, direction: str = 'asc') -> 'PyfireCollection[ModelType]':
+        """
+        Order the collection based on the given condition.
+
+        Args:
+            field (str): The field name to apply the order on.
+            direction (str): The order direction ('asc' or 'desc').
+
+        Returns:
+            PyfireCollection[ModelType]: A new PyfireCollection instance with the applied order.
+        """
+        coll = PyfireCollection(self.model_class)
+        coll._order_cond = OrderCondition(field, direction)
         if self._parent_model is not None:
             coll.set_parent(self._parent_model)
 
@@ -409,6 +433,25 @@ class PyfireDoc(BaseModel):
         """
         coll = PyfireCollection(cls)
         coll._where_cond = WhereCondition(field, operator, value)
+        return coll
+
+    @classmethod
+    def order(cls, field: str, direction: OrderDirection = "ASCENDING") -> PyfireCollection['PyfireDoc']:
+        """
+        Order the documents based on the given field.
+
+        Args:
+            field (str): The field name to apply the order on.
+            direction (str, optional): The order direction ('asc' or 'desc'). Defaults to 'asc'.
+
+        Returns:
+            PyfireCollection[PyfireDoc]: A PyfireCollection instance with the applied order.
+        """
+        # check if direction is valid
+        direction = OrderDirection(direction)
+
+        coll = PyfireCollection(cls)
+        coll._order_cond = OrderCondition(field, direction)
         return coll
 
     @classmethod

--- a/pyfireconsole/models/pyfire_model.py
+++ b/pyfireconsole/models/pyfire_model.py
@@ -54,13 +54,15 @@ class PyfireCollection(Generic[ModelType]):
         Yields:
             ModelType: The current document in the collection iteration.
         """
+        query = QueryRunner(self.obj_ref_key())
         if self._where_cond is not None:
-            self._collection = QueryRunner(self.obj_ref_key()).where(self._where_cond.field, self._where_cond.operator, self._where_cond.value)
+            query = query.where(self._where_cond.field, self._where_cond.operator, self._where_cond.value)
         else:
-            self._collection = QueryRunner(self.obj_ref_key()).all()
+            query = query.all()
 
         if self._order_cond is not None:
-            self._collection = QueryRunner(self.obj_ref_key()).order(self._order_cond.field, self._order_cond.direction)
+            query = query.order(self._order_cond.field, self._order_cond.direction)
+        self._collection = query.iter()
 
         for doc in self._collection:
             doc = self.model_class._doc_field_load(doc)
@@ -124,6 +126,7 @@ class PyfireCollection(Generic[ModelType]):
             PyfireCollection[ModelType]: A new PyfireCollection instance with the applied order.
         """
         coll = PyfireCollection(self.model_class)
+        coll._where_cond = self._where_cond
         coll._order_cond = OrderCondition(field, direction)
         if self._parent_model is not None:
             coll.set_parent(self._parent_model)

--- a/pyfireconsole/models/pyfire_model.py
+++ b/pyfireconsole/models/pyfire_model.py
@@ -4,9 +4,8 @@ import inflection
 from google.api_core.datetime_helpers import DatetimeWithNanoseconds
 from pydantic import BaseModel
 
-from pyfireconsole.models.order_condition import OrderCondition
 from pyfireconsole.queries.get_query import DocNotFoundException
-from pyfireconsole.queries.order_query import OrderDirection
+from pyfireconsole.queries.order_query import OrderCondition, OrderDirection
 from pyfireconsole.queries.query_runner import QueryRunner
 from pyfireconsole.queries.where_clouse import WhereCondition
 

--- a/pyfireconsole/models/pyfire_model.py
+++ b/pyfireconsole/models/pyfire_model.py
@@ -114,13 +114,13 @@ class PyfireCollection(Generic[ModelType]):
 
         return coll
 
-    def order(self, field: str, direction: str = 'asc') -> 'PyfireCollection[ModelType]':
+    def order(self, field: str, direction: str = 'ASCENDING') -> 'PyfireCollection[ModelType]':
         """
         Order the collection based on the given condition.
 
         Args:
             field (str): The field name to apply the order on.
-            direction (str): The order direction ('asc' or 'desc').
+            direction (str): The order direction, 'ASCENDING' or 'DESCENDING'. Defaults to 'ASCENDING'.
 
         Returns:
             PyfireCollection[ModelType]: A new PyfireCollection instance with the applied order.
@@ -445,7 +445,7 @@ class PyfireDoc(BaseModel):
 
         Args:
             field (str): The field name to apply the order on.
-            direction (str, optional): The order direction ('asc' or 'desc'). Defaults to 'asc'.
+            direction (str, optional): The order direction ('ASCENDING' or 'DESCENDING'). Defaults to 'ASCENDING'.
 
         Returns:
             PyfireCollection[PyfireDoc]: A PyfireCollection instance with the applied order.

--- a/pyfireconsole/queries/abstract_query.py
+++ b/pyfireconsole/queries/abstract_query.py
@@ -1,6 +1,7 @@
 from typing import Dict, Optional
 
 from google.cloud.firestore_v1.document import DocumentReference, DocumentSnapshot
+from google.cloud.firestore_v1.base_query import BaseQuery
 
 from pyfireconsole.db.connection import FirestoreConnection
 
@@ -10,8 +11,11 @@ class AbstractQuery:
         self.conn = conn
         return self
 
-    def collection_ref(self, collection_key: str):
-        return self.conn.collection(collection_key)
+    def collection_ref(self, collection_key_or_query: str | BaseQuery) -> DocumentReference | BaseQuery:
+        if isinstance(collection_key_or_query, str):
+            return self.conn.collection(collection_key_or_query)
+        else:
+            return collection_key_or_query
 
     def exec(self):
         raise NotImplementedError

--- a/pyfireconsole/queries/abstract_query.py
+++ b/pyfireconsole/queries/abstract_query.py
@@ -1,7 +1,7 @@
 from typing import Dict, Optional
 
-from google.cloud.firestore_v1.document import DocumentReference, DocumentSnapshot
 from google.cloud.firestore_v1.base_query import BaseQuery
+from google.cloud.firestore_v1.document import DocumentReference, DocumentSnapshot
 
 from pyfireconsole.db.connection import FirestoreConnection
 

--- a/pyfireconsole/queries/all_query.py
+++ b/pyfireconsole/queries/all_query.py
@@ -1,10 +1,11 @@
-from pyfireconsole.queries.abstract_query import AbstractQuery, _doc_to_dict
+from pyfireconsole.queries.abstract_query import AbstractQuery
+from google.cloud.firestore_v1.collection import CollectionReference
+from google.cloud.firestore_v1.base_query import BaseQuery
 
 
 class AllQuery(AbstractQuery):
-    def __init__(self, collection_key: str):
-        self.collection_key = collection_key
+    def __init__(self, collection_key_or_query: str | BaseQuery):
+        self.collection_key_or_query = collection_key_or_query
 
-    def exec(self) -> list[dict]:
-        docs = self.collection_ref(self.collection_key).stream()
-        return [dict(_doc_to_dict(doc) or {}, id=doc.id) for doc in docs]
+    def exec(self) -> BaseQuery | CollectionReference:
+        return self.collection_ref(self.collection_key_or_query)

--- a/pyfireconsole/queries/all_query.py
+++ b/pyfireconsole/queries/all_query.py
@@ -1,6 +1,7 @@
-from pyfireconsole.queries.abstract_query import AbstractQuery
-from google.cloud.firestore_v1.collection import CollectionReference
 from google.cloud.firestore_v1.base_query import BaseQuery
+from google.cloud.firestore_v1.collection import CollectionReference
+
+from pyfireconsole.queries.abstract_query import AbstractQuery
 
 
 class AllQuery(AbstractQuery):

--- a/pyfireconsole/queries/order_query.py
+++ b/pyfireconsole/queries/order_query.py
@@ -1,7 +1,8 @@
 
 from enum import Enum
 
-from pyfireconsole.queries.abstract_query import AbstractQuery, _doc_to_dict
+from pyfireconsole.queries.abstract_query import AbstractQuery
+from google.cloud.firestore_v1.base_query import BaseQuery
 
 
 class OrderDirection(str, Enum):
@@ -10,13 +11,14 @@ class OrderDirection(str, Enum):
 
 
 class OrderQuery(AbstractQuery):
-    def __init__(self, collection_key: str, field: str, direction: OrderDirection):
-        self.collection_key = collection_key
+    def __init__(self, collection_key_or_query: str | BaseQuery, field: str, direction: OrderDirection):
+        self.collection_key_or_query = collection_key_or_query
         self.field = field
         self.direction = direction
 
     def exec(self):
-        docs = self.collection_ref(self.collection_key).order_by(
+        base = self.collection_ref(self.collection_key_or_query)
+
+        return base.order_by(
             self.field, direction=self.direction
-        ).stream()
-        return [dict(_doc_to_dict(doc) or {}, id=doc.id) for doc in docs]
+        )

--- a/pyfireconsole/queries/order_query.py
+++ b/pyfireconsole/queries/order_query.py
@@ -11,6 +11,15 @@ class OrderDirection(str, Enum):
     DESCENDING = "DESCENDING"
 
 
+class OrderCondition:
+    field: str
+    direction: str
+
+    def __init__(self, field: str, direction: str):
+        self.field = field
+        self.direction = direction
+
+
 class OrderQuery(AbstractQuery):
     def __init__(self, collection_key_or_query: str | BaseQuery, field: str, direction: OrderDirection):
         self.collection_key_or_query = collection_key_or_query

--- a/pyfireconsole/queries/order_query.py
+++ b/pyfireconsole/queries/order_query.py
@@ -1,0 +1,22 @@
+
+from enum import Enum
+
+from pyfireconsole.queries.abstract_query import AbstractQuery, _doc_to_dict
+
+
+class OrderDirection(str, Enum):
+    ASCENDING = "ASCENDING"
+    DESCENDING = "DESCENDING"
+
+
+class OrderQuery(AbstractQuery):
+    def __init__(self, collection_key: str, field: str, direction: OrderDirection):
+        self.collection_key = collection_key
+        self.field = field
+        self.direction = direction
+
+    def exec(self):
+        docs = self.collection_ref(self.collection_key).order_by(
+            self.field, direction=self.direction
+        ).stream()
+        return [dict(_doc_to_dict(doc) or {}, id=doc.id) for doc in docs]

--- a/pyfireconsole/queries/order_query.py
+++ b/pyfireconsole/queries/order_query.py
@@ -1,8 +1,9 @@
 
 from enum import Enum
 
-from pyfireconsole.queries.abstract_query import AbstractQuery
 from google.cloud.firestore_v1.base_query import BaseQuery
+
+from pyfireconsole.queries.abstract_query import AbstractQuery
 
 
 class OrderDirection(str, Enum):

--- a/pyfireconsole/queries/query_runner.py
+++ b/pyfireconsole/queries/query_runner.py
@@ -1,6 +1,7 @@
 from typing import Any, Dict, Generator
-from google.cloud.firestore_v1.document import DocumentSnapshot
+
 from google.cloud.firestore_v1.base_query import BaseQuery
+from google.cloud.firestore_v1.document import DocumentSnapshot
 
 from pyfireconsole.db.connection import conn
 from pyfireconsole.queries.abstract_query import _doc_to_dict

--- a/pyfireconsole/queries/query_runner.py
+++ b/pyfireconsole/queries/query_runner.py
@@ -4,6 +4,7 @@ from pyfireconsole.db.connection import conn
 from pyfireconsole.queries.all_query import AllQuery
 from pyfireconsole.queries.delete_query import DeleteQuery
 from pyfireconsole.queries.get_query import GetQuery
+from pyfireconsole.queries.order_query import OrderQuery
 from pyfireconsole.queries.save_query import SaveQuery
 from pyfireconsole.queries.where_query import WhereQuery
 
@@ -18,6 +19,9 @@ class QueryRunner:
 
     def where(self, field: str, operator: str, value: str) -> list[Dict]:
         return WhereQuery(self.collection_key, field, operator, value).set_conn(self.conn).exec()
+
+    def order(self, field: str, direction: str) -> list[Dict]:
+        return OrderQuery(self.collection_key, field, direction).set_conn(self.conn).exec()
 
     def all(self) -> list[Dict]:
         return AllQuery(self.collection_key).set_conn(self.conn).exec()

--- a/pyfireconsole/queries/where_query.py
+++ b/pyfireconsole/queries/where_query.py
@@ -1,4 +1,4 @@
-from google.cloud.firestore_v1.base_query import FieldFilter, BaseQuery
+from google.cloud.firestore_v1.base_query import BaseQuery, FieldFilter
 from google.cloud.firestore_v1.collection import CollectionReference
 
 from pyfireconsole.queries.abstract_query import AbstractQuery

--- a/pyfireconsole/queries/where_query.py
+++ b/pyfireconsole/queries/where_query.py
@@ -1,19 +1,21 @@
-from google.cloud.firestore_v1.base_query import FieldFilter
+from google.cloud.firestore_v1.base_query import FieldFilter, BaseQuery
+from google.cloud.firestore_v1.collection import CollectionReference
 
-from pyfireconsole.queries.abstract_query import AbstractQuery, _doc_to_dict
+from pyfireconsole.queries.abstract_query import AbstractQuery
 
 
 class WhereQuery(AbstractQuery):
-    def __init__(self, collection_key: str, field: str, operator: str, value: str):
-        self.collection_key = collection_key
+    def __init__(self, collection_key_or_query: str | BaseQuery, field: str, operator: str, value: str):
+        self.collection_key_or_query = collection_key_or_query
         self.field = field
         self.operator = operator
         self.value = value
 
-    def exec(self) -> list[dict]:
-        docs = self.collection_ref(self.collection_key).where(
+    def exec(self) -> BaseQuery:
+        base = self.collection_ref(self.collection_key_or_query)
+
+        return base.where(
             # We can't use FieldFilter because we use python-mock-firestore lib for testing
             # filter=FieldFilter(self.field, self.operator, self.value)
             self.field, self.operator, self.value
-        ).stream()
-        return [dict(_doc_to_dict(doc) or {}, id=doc.id) for doc in docs]
+        )

--- a/tests/test_usecase.py
+++ b/tests/test_usecase.py
@@ -369,6 +369,34 @@ def test_order(mock_db):
         Book.order("title", "invalid_direction")
 
 
+def test_combination_order_and_where(mock_db):
+    Book.new(
+        title="Math",
+        user_id="12345",
+        published_at=datetime.now(),
+        authors=["John", "Mary"],
+        publisher_ref="publisher/12345",
+    ).save()
+    Book.new(
+        title="History",
+        user_id="12345",
+        published_at=datetime.now(),
+        authors=["John", "Mary"],
+        publisher_ref="publisher/12345",
+    ).save()
+    Book.new(
+        title="English",
+        user_id="12345",
+        published_at=datetime.now(),
+        authors=["John", "Mary"],
+        publisher_ref="publisher/12345",
+    ).save()
+
+    assert [b.title for b in Book.where("title", "==", "Math").order("title", "DESCENDING")] == ["Math"]
+    assert [b.title for b in Book.where("title", "==", "Math").order("title", "ASCENDING")] == ["Math"]
+    assert [b.title for b in Book.where("title", "==", "Math").order("title")] == ["Math"]
+
+
 def test_table_names():
     class User(PyfireDoc):
         pass

--- a/tests/test_usecase.py
+++ b/tests/test_usecase.py
@@ -7,7 +7,8 @@ from pyfireconsole.models.association import belongs_to, has_many, resolve_pyfir
 from pyfireconsole.models.pyfire_model import DocumentRef, PyfireCollection, PyfireDoc
 from mockfirestore import MockFirestore
 
-from pyfireconsole.queries.get_query import DocNotFoundException  # type: ignore
+from pyfireconsole.queries.get_query import DocNotFoundException
+from pyfireconsole.queries.order_query import OrderDirection  # type: ignore
 
 
 class I18n_Name(PyfireDoc):
@@ -334,6 +335,38 @@ def test_delete(mock_db):
 
     with pytest.raises(DocNotFoundException):
         Book.find(book1.id)
+
+
+def test_order(mock_db):
+    Book.new(
+        title="Math",
+        user_id="12345",
+        published_at=datetime.now(),
+        authors=["John", "Mary"],
+        publisher_ref="publisher/12345",
+    ).save()
+    Book.new(
+        title="History",
+        user_id="12345",
+        published_at=datetime.now(),
+        authors=["John", "Mary"],
+        publisher_ref="publisher/12345",
+    ).save()
+    Book.new(
+        title="English",
+        user_id="12345",
+        published_at=datetime.now(),
+        authors=["John", "Mary"],
+        publisher_ref="publisher/12345",
+    ).save()
+
+    assert [b.title for b in Book.order("title", "DESCENDING")] == ["Math", "History", "English"]
+    assert [b.title for b in Book.order("title", "ASCENDING")] == ["English", "History", "Math"]
+    assert [b.title for b in Book.order("title", OrderDirection.ASCENDING)] == ["English", "History", "Math"]
+    assert [b.title for b in Book.order("title")] == ["English", "History", "Math"]  # default direction is ASCENDING
+
+    with pytest.raises(ValueError):
+        Book.order("title", "invalid_direction")
 
 
 def test_table_names():


### PR DESCRIPTION
WHY
Implementing operators that can be done with Firestore.

WHAT
Added the Order clause. Also made it possible to chain Where and Order together.

```
print(Book.where("title", "==", "test").order("published_at", "ASCENDING"))
```